### PR TITLE
Update head-dedupe.js

### DIFF
--- a/head-dedupe.js
+++ b/head-dedupe.js
@@ -52,7 +52,9 @@ function insertAppendMonkeyPatchForHeadDeDupe(window) {
 
         // 7. Return undefined.
         return undefined;
-      }
+      },
+      configurable: true,
+      writable: true
     });
   }
 


### PR DESCRIPTION
This reflects the latest version of the polyfill from MDN (adds configurable: true, writable: true).

This fixes an issue in IE11 where other libs try to extend Array (and implement .find) which leads to 
```SCRIPT5045: Assignment to read-only properties is not allowed in strict mode```

For reference:
https://github.com/mobxjs/mobx/issues/1028

Is it possible to do a release after merge so we can wipe our caches?